### PR TITLE
Update homepage with Chinese AI search paper

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>GEO Citation Lab · 数据集、报告与论文</title>
+  <meta name="description" content="GEO Citation Lab：CN-GEO 数据集、生成式搜索引用实验、中文 AI 搜索实证研究与 54 篇 GEO / AEO / AI Search 论文合集。" />
   <style>
     :root {
       --paper: #f6f1e7;
@@ -196,19 +197,19 @@
       <span class="eyebrow">geo-citation-lab</span>
       <h1>GEO 数据集、实验报告与论文合集</h1>
       <p class="sub">
-        一个公开资料仓库，集中呈现国内 AI 引用数据、信源生态与官网来源渗透分析、AI 搜索引用机制实验报告，以及 GEO / AEO / AI Search 相关论文 PDF。原有实验对应论文：
-        <a href="https://arxiv.org/abs/2604.25707">From Citation Selection to Citation Absorption: A Measurement Framework for Generative Engine Optimization Across AI Search Platforms</a>。
+        一个公开资料仓库，集中呈现国内 AI 引用数据、信源生态与官网来源渗透分析、AI 搜索引用机制实验报告，以及 GEO / AEO / AI Search 相关论文 PDF。研究主线包括跨平台引用选择与吸收测量，以及中文生成式搜索平台的引用、实体曝光和跨界面一致性分析。
       </p>
 
       <div class="stats">
         <div class="stat"><strong>214,119</strong><span>国内 AI 引用记录</span></div>
         <div class="stat"><strong>12</strong><span>国内 AI 平台形态</span></div>
         <div class="stat"><strong>9,878</strong><span>规范信源</span></div>
-        <div class="stat"><strong>53</strong><span>论文 PDF</span></div>
+        <div class="stat"><strong>54</strong><span>论文 PDF</span></div>
       </div>
 
       <div class="actions">
         <a class="btn btn-primary" href="./03-cn-geo-citation-dataset/reports/final/CN-GEO_%E5%A4%9A%E7%BB%B4%E6%95%B0%E6%8D%AE%E5%88%86%E6%9E%90%E6%8A%A5%E5%91%8A.html">打开 CN-GEO 分析报告</a>
+        <a class="btn btn-secondary" href="./02-geo-aeo-ai-search-papers/04_AI搜索实证/04_AI搜索实证_Chinese_Language_Generative_Search_Engines_Citation_Study.pdf">阅读中文 AI 搜索论文</a>
         <a class="btn btn-secondary" href="./01-geo-experiment-data-report/04-repet/final_report.html">打开实验 HTML 报告</a>
         <a class="btn btn-secondary" href="./02-geo-aeo-ai-search-papers/">进入论文合集</a>
         <a class="btn btn-secondary" href="https://github.com/yaojingang/geo-citation-lab">查看 GitHub 仓库</a>
@@ -251,6 +252,13 @@
           <a href="https://arxiv.org/abs/2604.25707">打开 Abstract 页面</a>
           <br />
           <a href="https://arxiv.org/pdf/2604.25707">打开 PDF Paper</a>
+        </article>
+        <article class="card">
+          <h2>中文 AI 搜索实证论文</h2>
+          <p>覆盖四个中文大模型平台的 Web 与 App 界面，分析引用行为、实体曝光与跨界面一致性。</p>
+          <a href="./02-geo-aeo-ai-search-papers/04_AI搜索实证/04_AI搜索实证_Chinese_Language_Generative_Search_Engines_Citation_Study.pdf">打开仓库 PDF</a>
+          <br />
+          <a href="https://arxiv.org/abs/2607.15771">查看 arXiv 摘要</a>
         </article>
         <article class="card">
           <h2>仓库源码与数据</h2>


### PR DESCRIPTION
## 变更内容

- 更新首页研究说明，加入中文生成式搜索的引用、实体曝光与跨界面一致性研究主线
- 将首页论文总数从 53 更新为 54
- 新增中文 AI 搜索论文快速按钮和详细卡片入口
- 补充首页 meta description

## 背景

PR #2 已将 arXiv 2607.15771v1 及相关清单合并到仓库，首页还缺少对应说明和直达入口。

## 用户影响

读者可以从 GitHub Pages 首屏直接打开新论文，也可从资源卡片进入仓库 PDF 或 arXiv 摘要页。

## 验证

- 桌面端 1440px 真实渲染通过
- 移动端 375px 真实渲染通过，页面横向滚动宽度与视口一致
- 16 个链接已解析，全部本地目标存在
- HTML diff 格式检查通过

仓库当前没有可自动识别的测试命令。
