### PR TITLE
Add AI-ready viewer distribution and split licensing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,127 @@
+name: Publish lightweight viewer
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "geo-citation-lab-publish-${{ github.ref }}"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify distribution
+        run: python3 scripts/verify_distribution.py
+
+      - name: Build release assets
+        run: python3 scripts/build_viewer.py --package
+
+      - name: Verify release tag version
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: >-
+          python3 -c "import json, os, pathlib;
+          version=json.loads(pathlib.Path('deploy/manifest.json').read_text())['distribution_version'];
+          status=json.loads(pathlib.Path('deploy/manifest.json').read_text())['release_status'];
+          expected='v'+version;
+          actual=os.environ['RELEASE_TAG'];
+          assert actual == expected, f'release tag {actual} must equal {expected}';
+          assert status == 'released', 'release_status must be released before tagging'"
+
+      - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: dist/viewer
+
+      - name: Upload release assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: viewer-release-assets
+          path: dist/release/*
+          if-no-files-found: error
+
+  verify-windows-installer:
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Build release assets
+        run: python scripts/build_viewer.py --package
+
+      - name: Install twice to verify idempotency
+        shell: powershell
+        run: |
+          $installDir = Join-Path $env:RUNNER_TEMP "geo-citation-lab-viewer"
+          ./scripts/install.ps1 -AssetBase "./dist/release" -InstallDir $installDir -NoOpen
+          ./scripts/install.ps1 -AssetBase "./dist/release" -InstallDir $installDir -NoOpen
+          $report = Join-Path $installDir "01-geo-experiment-data-report/04-repet/final_report.html"
+          Remove-Item -LiteralPath $report
+          ./scripts/install.ps1 -AssetBase "./dist/release" -InstallDir $installDir -NoOpen
+          if (-not (Test-Path $report)) {
+            throw "Installer did not repair a missing report"
+          }
+          $backups = @(Get-ChildItem "$installDir.previous.*" -Directory)
+          if ($backups.Count -ne 1) {
+            throw "Installer rollback backup was not preserved"
+          }
+
+  deploy-pages:
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - build
+      - verify-windows-installer
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - build
+      - verify-windows-installer
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: viewer-release-assets
+          path: release-assets
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" release-assets/* --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" release-assets/* \
+              --verify-tag \
+              --generate-notes \
+              --title "$GITHUB_REF_NAME"
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish lightweight viewer
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+dist/
 __pycache__/
 *.pyc
 .env

--- a/02-geo-aeo-ai-search-papers/index.html
+++ b/02-geo-aeo-ai-search-papers/index.html
@@ -652,12 +652,15 @@ button { touch-action: manipulation; }
 
   <footer class="foot">
     <span>GEO Citation Lab · static HTML generated from <code>论文清单.csv</code></span>
-    <span><a href="./00_资料说明/checksums.sha256">SHA-256</a> · <a href="./">返回目录</a></span>
+    <span><a rel="license" href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a> · <a href="../LICENSE">许可范围</a> · <a href="./00_资料说明/checksums.sha256">SHA-256</a> · <a href="./">返回目录</a></span>
   </footer>
 </div>
 
 <script>
 const CSV_PATH = "./00_资料说明/论文清单.csv";
+const EMBEDDED_CSV = window.GEO_VIEWER_CSV || "";
+const PDF_BASE_URL = window.GEO_PDF_BASE_URL || "";
+const USE_SOURCE_PDF_URLS = window.GEO_VIEWER_USE_SOURCE_PDF_URLS || false;
 const NEW_URLS = new Set([
   "https://arxiv.org/pdf/2606.04362",
   "https://arxiv.org/pdf/2606.20065",
@@ -746,7 +749,11 @@ function parseCsv(text) {
     headers.forEach((h, i) => { item[h] = r[i] || ""; });
     item.index = index;
     item.isNew = NEW_URLS.has(item.URL);
-    item.filePath = `./${item["分类"]}/${item["文件名"]}`;
+    item.sourceUrl = safeExternalUrl(item.URL);
+    const relativeFilePath = `${item["分类"]}/${item["文件名"]}`;
+    item.filePath = USE_SOURCE_PDF_URLS
+      ? item.sourceUrl
+      : (PDF_BASE_URL ? `${PDF_BASE_URL}${relativeFilePath}` : `./${relativeFilePath}`);
     item.yearSort = parseInt((item["年份"].match(/\d{4}/) || ["0"])[0], 10);
     item.searchText = `${item["分类"]} ${item["论文题名"]} ${item["年份"]} ${item["来源"]} ${item["备注"]}`.toLowerCase();
     return item;
@@ -773,6 +780,15 @@ function escapeHtml(value) {
     '"': "&quot;",
     "'": "&#39;"
   }[ch]));
+}
+
+function safeExternalUrl(value) {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" || parsed.protocol === "http:" ? parsed.href : "";
+  } catch (_error) {
+    return "";
+  }
 }
 
 function getFiltered() {
@@ -815,6 +831,9 @@ function renderCategories() {
 
 function renderPaper(paper) {
   const newTag = paper.isNew ? `<span class="tag new">近期新增</span>` : "";
+  const paperAction = paper.filePath
+    ? `<a class="pdf-link" href="${escapeHtml(encodeURI(paper.filePath))}" target="_blank" rel="noopener noreferrer">打开 PDF</a>`
+    : `<span class="pdf-link" aria-disabled="true">来源链接不可用</span>`;
   return `<article class="paper-row">
     <div class="paper-main">
       <h3 class="paper-title">${escapeHtml(paper["论文题名"])}</h3>
@@ -826,7 +845,7 @@ function renderPaper(paper) {
       <p class="paper-note">${escapeHtml(paper["备注"])}</p>
     </div>
     <div class="paper-action">
-      <a class="pdf-link" href="${encodeURI(paper.filePath)}">打开 PDF</a>
+      ${paperAction}
     </div>
   </article>`;
 }
@@ -946,9 +965,12 @@ function drawTopicMap() {
 
 async function init() {
   try {
-    const response = await fetch(CSV_PATH);
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const csv = await response.text();
+    let csv = EMBEDDED_CSV;
+    if (!csv) {
+      const response = await fetch(CSV_PATH);
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      csv = await response.text();
+    }
     allPapers = parseCsv(csv);
     renderMetrics();
     render();

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# GEO Citation Lab agent instructions
+
+## Intent routing
+
+Map natural-language requests to one of these modes:
+
+- `install`, `open`, `本地安装`, `打开`: install the lightweight Viewer.
+- `deploy`, `发布`, `GitHub Pages`: publish the Viewer after confirming the external target.
+- `full data`, `完整数据`, `分析环境`: clone the complete repository and prepare the nested Python project.
+- `read`, `browse`, `看看报告`: open the canonical site when no local copy is required.
+
+Use `deploy/manifest.json` as the machine-readable source of asset names, version, size limits,
+entrypoint, and deployment workflow.
+
+## Lightweight Viewer installation
+
+1. Require `release_status` to be `released`, then use the version-pinned Release assets listed
+   in `deploy/manifest.json`.
+2. Download both the Viewer ZIP and its SHA-256 sidecar.
+3. Inspect the installer before execution. Never pipe an unreviewed remote script into a shell.
+4. Use `scripts/install.sh` on macOS/Linux and `scripts/install.ps1` on Windows.
+5. Keep the default installation directory unless the user provides a destination.
+6. Open `index.html` after installation unless the user asks for download only.
+7. Report the installed path, entrypoint, checksum result, and any backup path.
+
+The installer must remain idempotent. An update may replace only a directory containing
+`.geo-citation-lab-install`. Preserve the previous installation as a timestamped backup.
+
+If `release_status` is `pending` or the pinned Release does not exist, explain that the remote
+package has not been published. A maintainer working inside a repository checkout may run
+`python3 scripts/build_viewer.py --package` and install from `dist/release`.
+
+## GitHub Pages deployment
+
+Treat repository creation, visibility changes, Pages source changes, tags, pushes, and releases as
+external mutations.
+
+1. Resolve the authenticated GitHub identity and exact `OWNER/REPO`.
+2. Read `deployment.requires_license_compliance` and `required_notice_files` from the manifest.
+   Keep every required notice file in the deployed Viewer, preserve the requested attribution, and
+   identify any changes made to CC BY 4.0 content.
+3. Show the target repository and confirm public visibility before creating or changing it.
+4. Confirm before switching an existing Pages source to GitHub Actions.
+5. Run `python3 scripts/verify_distribution.py`.
+6. Use `.github/workflows/publish.yml`; it publishes `dist/viewer`, not the repository root.
+7. After deployment, read the workflow conclusion and open the returned Pages URL.
+8. Report the public URL, workflow run, source commit, release tag when applicable, and retained
+   license notices.
+
+The canonical repository uses `https://yaojingang.github.io/geo-citation-lab/`.
+
+## Full repository mode
+
+The complete working tree is approximately 568 MiB and contains large research assets. State the
+expected size before cloning. Read the directory-level README for the selected research line.
+Python analysis for `03-cn-geo-citation-dataset` requires Python 3.11 or newer and `uv`.
+
+Review `LICENSE`, `LICENSE-CODE`, `LICENSE-CONTENT`, and `THIRD_PARTY_NOTICES.md` before
+redistribution. Code is MIT licensed, original GEO Citation Lab content is CC BY 4.0, and paper
+PDF rights remain with their authors or publishers.
+
+## Maintainer verification
+
+Run these commands before a Pages deployment or Release:
+
+```bash
+python3 -m py_compile scripts/build_viewer.py scripts/verify_distribution.py
+bash -n scripts/install.sh
+python3 scripts/verify_distribution.py
+```
+
+For a release tag, require `v<distribution_version>` from `deploy/manifest.json`. The release ZIP
+must stay within `modes.viewer.max_uncompressed_mib` and must exclude PDF, Parquet, DuckDB, JSONL,
+and font files. Set `release_status` to `released` in the tagged commit; leave it as `pending`
+until the release is ready.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+# GEO Citation Lab licensing
+
+This repository uses separate licenses for software and original content.
+
+## Software
+
+Source code, analysis scripts, installation scripts, workflow files, agent skills, and the
+software portions of HTML, CSS, and JavaScript files are licensed under the MIT License in
+`LICENSE-CODE`.
+
+## Original content
+
+Original prose, research reports, documentation, visualizations, and catalog metadata created for
+GEO Citation Lab are licensed under the Creative Commons Attribution 4.0 International license
+(CC BY 4.0) described in `LICENSE-CONTENT`.
+
+## Third-party material
+
+These licenses cover only rights held by the GEO Citation Lab contributors. Academic paper PDFs,
+source datasets, fonts, trademarks, and other third-party material keep their original terms.
+Directory-level license files and `THIRD_PARTY_NOTICES.md` take precedence for those materials.
+
+Redistributions must preserve this file, `LICENSE-CODE`, `LICENSE-CONTENT`, applicable
+directory-level licenses, and `THIRD_PARTY_NOTICES.md`.

--- a/LICENSE-CODE
+++ b/LICENSE-CODE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Yao Jingang and GEO Citation Lab contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE-CONTENT
+++ b/LICENSE-CONTENT
@@ -1,0 +1,19 @@
+# Creative Commons Attribution 4.0 International
+
+Copyright (c) 2026 Yao Jingang and GEO Citation Lab contributors
+
+Except where another source or license is identified, original prose, research reports,
+documentation, visualizations, and catalog metadata created for GEO Citation Lab are licensed
+under the Creative Commons Attribution 4.0 International license (CC BY 4.0):
+
+https://creativecommons.org/licenses/by/4.0/
+
+When sharing or adapting this material, provide reasonable attribution, link to the license, and
+indicate whether you made changes. The requested attribution is:
+
+> GEO Citation Lab contributors, "GEO Citation Lab",
+> https://github.com/yaojingang/geo-citation-lab, CC BY 4.0.
+
+This license applies only to rights held by the GEO Citation Lab contributors. It does not cover
+academic paper PDFs, source datasets, fonts, trademarks, or other third-party material.
+`THIRD_PARTY_NOTICES.md` and directory-level license files identify those separate terms.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,32 @@ GEO Citation Lab 是一个面向 AI 搜索引用机制的公开实证研究工�
 
 `提问 → 搜索触发 → 信源选择 → 内容吸收 → 实体曝光 → 跨平台与跨终端差异`
 
+## 在 AI 客户端一句话安装
+
+把下面这句话发送给具有网络和本地文件权限的 AI 客户端：
+
+> 安装 GEO Citation Lab 的轻量阅读版并打开：
+> https://github.com/yaojingang/geo-citation-lab
+
+首个 `v0.1.0` Release 发布后，AI 客户端会下载版本固定的 Viewer、验证 SHA-256、
+解压并打开 `index.html`。Viewer
+包含自包含研究报告和可搜索论文目录，体积上限为 15 MiB，无需 Git、Python、Node
+或 Docker。论文 PDF 与完整研究数据保留在线入口。
+
+当前 `deploy/manifest.json` 中的 `release_status` 为 `pending`，表示远端安装资产尚未
+发布。维护者准备好首个 Release 后，将状态改为 `released`。
+
+| 你对 AI 说 | 执行结果 |
+| --- | --- |
+| “安装并打开 GEO Citation Lab” | 安装轻量 Viewer，并在默认浏览器打开 |
+| “把 GEO Citation Lab Viewer 部署到我的 GitHub Pages” | 保留许可与署名文件，确认目标仓库与公开可见性后运行 Pages 发布流程 |
+| “下载完整数据并准备分析环境” | 提示约 568 MiB 体积，再克隆仓库并配置 Python 3.11 与 `uv` |
+
+网页聊天客户端通常没有本地文件权限，可以直接使用
+[在线首页](https://yaojingang.github.io/geo-citation-lab/)。本地 AI 客户端应遵循
+[`AGENTS.md`](./AGENTS.md) 和
+[`deploy/manifest.json`](./deploy/manifest.json) 中的安装契约。
+
 | 研究资产 | 当前规模 |
 | --- | ---: |
 | CN-GEO 原始引用记录 | 214,119 条 |
@@ -92,9 +118,37 @@ CN-GEO 当前发布版包含 `214,119` 条原始引用记录、`64` 个 JSONL �
 - 跨平台实验来自一次静态研究快照，当前没有为每条记录提供统一采集时间戳。
 - CN-GEO 原始层缺少完整回答、回答批次、模型版本和采集时间。来源覆盖与跨平台共识可以直接研究，趋势、情感、严格引用排名和品牌推荐率需要更多回答级数据。
 - 不同论文、原始数据和清洗仓库采用各自的样本范围与处理口径。引用数字时，以对应论文或数据版本的说明为准。
-- 本仓库其余代码与报告当前没有设置顶层统一许可。再发布或商业使用前，请确认相应目录和原始材料的授权范围。
+- 本仓库采用分范围许可：代码和自动化文件使用 MIT，自有报告、文档、可视化和目录元数据使用 CC BY 4.0。论文 PDF、来源数据和其他第三方材料维持原许可。
 
 完整的数据限制和验收结果见 [CN-GEO 数据集中文说明](./03-cn-geo-citation-dataset/data/数据集中文说明.md) 与 [数据质量报告](./03-cn-geo-citation-dataset/data/quality/release_date=2026-07-14/quality_report.md)。
+
+## 发布轻量 Viewer
+
+维护者可以在本地构建并验证发布包：
+
+```bash
+python3 scripts/build_viewer.py --package
+python3 scripts/verify_distribution.py
+```
+
+推送 `main` 后，[`publish.yml`](./.github/workflows/publish.yml) 会部署轻量 Viewer 到
+GitHub Pages。推送与 `deploy/manifest.json` 中 `distribution_version` 一致的 `v*`
+标签后，同一工作流会发布 Viewer ZIP、SHA-256、manifest 和两个安装器。
+
+首次发布 Release 时，维护者需在同一发布提交中把 `release_status` 从 `pending`
+改为 `released`，通过验证后再创建匹配版本的标签。安装器和 manifest 都使用该版本
+固定的 Release URL，避免 `main` 与 `latest` 在发布窗口内发生版本漂移。
+
+首次启用工作流部署时，需要在仓库 **Settings → Pages → Build and deployment** 中把
+Source 设置为 **GitHub Actions**。发布包的第三方材料边界见
+[`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md)。
+
+仓库采用分范围许可。代码、安装器、工作流和 Skill 使用
+[MIT](./LICENSE-CODE)；本仓库原创报告、文档、可视化和目录元数据使用
+[CC BY 4.0](./LICENSE-CONTENT)。用户可以复制、修改和公开部署 Viewer，发布时需要
+保留 [`LICENSE`](./LICENSE)、两个分范围许可文件与
+[`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md)，并注明来源和修改情况。论文
+PDF、来源数据和其他第三方材料维持各自的原始条款。
 
 ## 关注更新与参与
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ GEO Citation Lab 是一个面向 AI 搜索引用机制的公开实证研究工�
 > 安装 GEO Citation Lab 的轻量阅读版并打开：
 > https://github.com/yaojingang/geo-citation-lab
 
-首个 `v0.1.0` Release 发布后，AI 客户端会下载版本固定的 Viewer、验证 SHA-256、
-解压并打开 `index.html`。Viewer
+AI 客户端会下载版本固定的 `v0.1.0` Viewer、验证 SHA-256、解压并打开
+`index.html`。Viewer
 包含自包含研究报告和可搜索论文目录，体积上限为 15 MiB，无需 Git、Python、Node
 或 Docker。论文 PDF 与完整研究数据保留在线入口。
 
-当前 `deploy/manifest.json` 中的 `release_status` 为 `pending`，表示远端安装资产尚未
-发布。维护者准备好首个 Release 后，将状态改为 `released`。
+当前 `deploy/manifest.json` 中的 `release_status` 为 `released`，安装器使用
+`v0.1.0` 的固定 Release 资产地址。
 
 | 你对 AI 说 | 执行结果 |
 | --- | --- |
@@ -135,9 +135,10 @@ python3 scripts/verify_distribution.py
 GitHub Pages。推送与 `deploy/manifest.json` 中 `distribution_version` 一致的 `v*`
 标签后，同一工作流会发布 Viewer ZIP、SHA-256、manifest 和两个安装器。
 
-首次发布 Release 时，维护者需在同一发布提交中把 `release_status` 从 `pending`
-改为 `released`，通过验证后再创建匹配版本的标签。安装器和 manifest 都使用该版本
-固定的 Release URL，避免 `main` 与 `latest` 在发布窗口内发生版本漂移。
+准备下一个版本时，维护者先把 `release_status` 设为 `pending`，并同步更新
+`distribution_version`、安装器固定 URL 和 README 中的版本。发布提交再将状态设为
+`released`，通过验证后创建匹配版本的标签。安装器和 manifest 都使用版本固定的
+Release URL，避免 `main` 与 `latest` 在发布窗口内发生版本漂移。
 
 首次启用工作流部署时，需要在仓库 **Settings → Pages → Build and deployment** 中把
 Source 设置为 **GitHub Actions**。发布包的第三方材料边界见

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,31 @@
+# Third-party materials and distribution scope
+
+GEO Citation Lab collects research reports, datasets, metadata, and academic papers from several sources. Rights and reuse conditions can differ by directory and source.
+
+The lightweight Viewer release contains:
+
+- the repository landing page;
+- self-contained HTML reports maintained in this repository;
+- the searchable paper catalog and its metadata CSV;
+- the distribution manifest and this notice.
+
+The lightweight Viewer release excludes:
+
+- academic paper PDF files;
+- raw JSONL records;
+- CSV, Parquet, and DuckDB research datasets outside the paper metadata catalog;
+- fonts and other large binary research assets.
+
+Paper links in the Viewer point to the canonical GEO Citation Lab site or the original publication source. Copyright in each academic paper remains with its authors or publisher.
+
+The CN-GEO materials derive from
+[WENDAOstudy/cn-geo-citation-dataset](https://github.com/WENDAOstudy/cn-geo-citation-dataset),
+which identifies its dataset license as CC BY 4.0. Review the source dataset license and the
+directory-level documentation before redistribution or commercial use.
+
+This notice records the release package boundary. It does not grant additional rights to any
+third-party material.
+
+The repository's [MIT software license](./LICENSE-CODE) and
+[CC BY 4.0 original-content license](./LICENSE-CONTENT) apply only to rights held by GEO Citation
+Lab contributors. See [`LICENSE`](./LICENSE) for the scope map.

--- a/deploy/manifest.json
+++ b/deploy/manifest.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "name": "geo-citation-lab",
   "distribution_version": "0.1.0",
-  "release_status": "pending",
+  "release_status": "released",
   "dataset_version": "2.0.1",
   "source_repository": "https://github.com/yaojingang/geo-citation-lab",
   "canonical_site": "https://yaojingang.github.io/geo-citation-lab/",

--- a/deploy/manifest.json
+++ b/deploy/manifest.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "name": "geo-citation-lab",
+  "distribution_version": "0.1.0",
+  "release_status": "pending",
+  "dataset_version": "2.0.1",
+  "source_repository": "https://github.com/yaojingang/geo-citation-lab",
+  "canonical_site": "https://yaojingang.github.io/geo-citation-lab/",
+  "licensing": {
+    "scope_file": "LICENSE",
+    "code": {
+      "spdx": "MIT",
+      "file": "LICENSE-CODE"
+    },
+    "original_content": {
+      "spdx": "CC-BY-4.0",
+      "file": "LICENSE-CONTENT",
+      "attribution": "GEO Citation Lab contributors, GEO Citation Lab, https://github.com/yaojingang/geo-citation-lab, CC BY 4.0"
+    },
+    "third_party_notices": "THIRD_PARTY_NOTICES.md"
+  },
+  "default_mode": "viewer",
+  "modes": {
+    "viewer": {
+      "description": "Lightweight offline reader with self-contained reports and a searchable paper catalog.",
+      "asset": "https://github.com/yaojingang/geo-citation-lab/releases/download/v0.1.0/geo-citation-lab-viewer.zip",
+      "checksum": "https://github.com/yaojingang/geo-citation-lab/releases/download/v0.1.0/geo-citation-lab-viewer.zip.sha256",
+      "entrypoint": "index.html",
+      "max_uncompressed_mib": 15,
+      "runtime_requirements": []
+    },
+    "full": {
+      "description": "Complete research repository with datasets, papers, reports, and analysis pipelines.",
+      "git_url": "https://github.com/yaojingang/geo-citation-lab.git",
+      "approx_uncompressed_mib": 568,
+      "analysis_requirements": [
+        "Git",
+        "Python 3.11 or newer",
+        "uv"
+      ]
+    }
+  },
+  "deployment": {
+    "provider": "github-pages",
+    "workflow": ".github/workflows/publish.yml",
+    "public_visibility": true,
+    "requires_redistribution_authorization": false,
+    "requires_license_compliance": true,
+    "required_notice_files": [
+      "LICENSE",
+      "LICENSE-CODE",
+      "LICENSE-CONTENT",
+      "THIRD_PARTY_NOTICES.md"
+    ]
+  },
+  "release_assets": [
+    "geo-citation-lab-viewer.zip",
+    "geo-citation-lab-viewer.zip.sha256",
+    "geo-citation-lab-manifest.json",
+    "install.sh",
+    "install.ps1"
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -270,6 +270,11 @@
       <p class="note">
         说明：GitHub 代码页中直接点击 <code>.html</code> 文件通常只会显示源码。要获得“像网站一样可直接浏览”的体验，使用本仓库的 GitHub Pages 入口更稳妥。
       </p>
+      <p class="note">
+        许可：代码使用 <a href="./LICENSE-CODE">MIT</a>；本仓库原创报告、文档、可视化和目录元数据使用
+        <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>。
+        再发布时请保留 <a href="./LICENSE">许可范围说明</a>、署名和第三方材料声明。
+      </p>
     </section>
   </main>
 </body>

--- a/scripts/build_viewer.py
+++ b/scripts/build_viewer.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Build and package the lightweight GEO Citation Lab viewer."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import stat
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = REPO_ROOT / "dist" / "viewer"
+DEFAULT_PACKAGE_DIR = REPO_ROOT / "dist" / "release"
+MANIFEST_PATH = REPO_ROOT / "deploy" / "manifest.json"
+PAPER_DIR = REPO_ROOT / "02-geo-aeo-ai-search-papers"
+PAPER_CSV = PAPER_DIR / "00_资料说明" / "论文清单.csv"
+LOCAL_PAPER_PDF = (
+    "./02-geo-aeo-ai-search-papers/04_AI搜索实证/"
+    "04_AI搜索实证_Chinese_Language_Generative_Search_Engines_Citation_Study.pdf"
+)
+REMOTE_PAPER_PDF = (
+    "https://arxiv.org/pdf/2607.15771v1"
+)
+RELEASE_ASSET_NAME = "geo-citation-lab-viewer.zip"
+VIEWER_CHECKSUMS_NAME = "geo-citation-lab-files.sha256"
+RELEASE_FILENAMES = set(
+    json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))["release_assets"]
+)
+if RELEASE_ASSET_NAME not in RELEASE_FILENAMES:
+    raise ValueError(f"{RELEASE_ASSET_NAME} is missing from release_assets")
+
+
+def _assert_replaceable_output(output: Path) -> None:
+    resolved = output.resolve()
+    if resolved == Path(resolved.anchor) or resolved == REPO_ROOT.resolve():
+        raise ValueError(f"Unsafe viewer output path: {resolved}")
+
+    if output.exists():
+        dist_root = (REPO_ROOT / "dist").resolve()
+        if dist_root not in resolved.parents:
+            raise ValueError(
+                "Refusing to replace an existing directory outside the repository dist folder: "
+                f"{resolved}"
+            )
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _copy_file(source: Path, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+
+
+def _javascript_string_literal(value: str) -> str:
+    return (
+        json.dumps(value, ensure_ascii=False)
+        .replace("&", "\\u0026")
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
+
+
+def _build_root_index(target: Path) -> None:
+    html = (REPO_ROOT / "index.html").read_text(encoding="utf-8")
+    if LOCAL_PAPER_PDF not in html:
+        raise RuntimeError("Root index paper link marker was not found")
+    html = html.replace(LOCAL_PAPER_PDF, REMOTE_PAPER_PDF)
+    _write_text(target / "index.html", html)
+
+
+def _build_paper_catalog(target: Path) -> None:
+    html = (PAPER_DIR / "index.html").read_text(encoding="utf-8")
+    csv_text = PAPER_CSV.read_text(encoding="utf-8")
+    script_marker = "<script>\nconst CSV_PATH ="
+    if html.count(script_marker) != 1:
+        raise RuntimeError("Paper catalog script marker must occur exactly once")
+
+    viewer_config = (
+        "<script>\n"
+        f"window.GEO_VIEWER_CSV = {_javascript_string_literal(csv_text)};\n"
+        "window.GEO_VIEWER_USE_SOURCE_PDF_URLS = true;\n"
+        "</script>\n\n"
+    )
+    html = html.replace(script_marker, viewer_config + script_marker)
+    html = html.replace(
+        'href="./README.md"',
+        'href="https://github.com/yaojingang/geo-citation-lab/blob/main/'
+        '02-geo-aeo-ai-search-papers/README.md"',
+    )
+    html = html.replace(
+        'href="./00_资料说明/checksums.sha256"',
+        'href="https://github.com/yaojingang/geo-citation-lab/blob/main/'
+        '02-geo-aeo-ai-search-papers/00_资料说明/checksums.sha256"',
+    )
+
+    paper_target = target / "02-geo-aeo-ai-search-papers"
+    _write_text(paper_target / "index.html", html)
+    _copy_file(PAPER_CSV, paper_target / "00_资料说明" / PAPER_CSV.name)
+
+
+def _write_viewer_checksums(target: Path) -> None:
+    lines: list[str] = []
+    for source in sorted(path for path in target.rglob("*") if path.is_file()):
+        relative = source.relative_to(target).as_posix()
+        if "\n" in relative or "\r" in relative or "\\" in relative:
+            raise ValueError(f"Unsupported viewer path: {relative!r}")
+        digest = hashlib.sha256(source.read_bytes()).hexdigest()
+        lines.append(f"{digest}  {relative}")
+    _write_text(target / VIEWER_CHECKSUMS_NAME, "\n".join(lines) + "\n")
+
+
+def build_viewer(output: Path) -> Path:
+    output = output.expanduser()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    _assert_replaceable_output(output)
+
+    with tempfile.TemporaryDirectory(
+        prefix="geo-citation-lab-viewer-", dir=output.parent
+    ) as temporary:
+        stage = Path(temporary) / "viewer"
+        stage.mkdir()
+
+        _build_root_index(stage)
+        _build_paper_catalog(stage)
+        _copy_file(REPO_ROOT / ".nojekyll", stage / ".nojekyll")
+        _copy_file(
+            REPO_ROOT
+            / "01-geo-experiment-data-report"
+            / "04-repet"
+            / "final_report.html",
+            stage
+            / "01-geo-experiment-data-report"
+            / "04-repet"
+            / "final_report.html",
+        )
+        _copy_file(
+            REPO_ROOT
+            / "03-cn-geo-citation-dataset"
+            / "reports"
+            / "final"
+            / "CN-GEO_多维数据分析报告.html",
+            stage
+            / "03-cn-geo-citation-dataset"
+            / "reports"
+            / "final"
+            / "CN-GEO_多维数据分析报告.html",
+        )
+        _copy_file(MANIFEST_PATH, stage / "geo-citation-lab-manifest.json")
+        _copy_file(
+            REPO_ROOT / "THIRD_PARTY_NOTICES.md",
+            stage / "THIRD_PARTY_NOTICES.md",
+        )
+        for license_name in ("LICENSE", "LICENSE-CODE", "LICENSE-CONTENT"):
+            _copy_file(REPO_ROOT / license_name, stage / license_name)
+        _write_viewer_checksums(stage)
+
+        if output.exists():
+            shutil.rmtree(output)
+        stage.replace(output)
+
+    return output
+
+
+def _write_deterministic_zip(viewer: Path, archive: Path) -> None:
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(
+        archive, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9
+    ) as bundle:
+        for source in sorted(path for path in viewer.rglob("*") if path.is_file()):
+            relative = source.relative_to(viewer).as_posix()
+            info = zipfile.ZipInfo(relative, date_time=(2020, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = (stat.S_IFREG | 0o644) << 16
+            bundle.writestr(info, source.read_bytes(), compresslevel=9)
+
+
+def _assert_safe_package_dir(package_dir: Path) -> None:
+    resolved = package_dir.resolve()
+    if resolved == Path(resolved.anchor) or resolved == REPO_ROOT.resolve():
+        raise ValueError(f"Unsafe release asset directory: {resolved}")
+    if package_dir.is_symlink():
+        raise ValueError(f"Release asset directory cannot be a symlink: {package_dir}")
+
+    dist_root = (REPO_ROOT / "dist").resolve()
+    for name in RELEASE_FILENAMES:
+        target = package_dir / name
+        if target.is_symlink():
+            raise ValueError(f"Release asset target cannot be a symlink: {target}")
+        if target.exists() and dist_root not in resolved.parents:
+            raise ValueError(
+                "Refusing to replace existing release assets outside the repository dist folder: "
+                f"{target}"
+            )
+
+
+def package_viewer(viewer: Path, package_dir: Path) -> dict[str, Path]:
+    package_dir = package_dir.expanduser()
+    _assert_safe_package_dir(package_dir)
+    package_dir.mkdir(parents=True, exist_ok=True)
+    archive = package_dir / RELEASE_ASSET_NAME
+    checksum = package_dir / f"{RELEASE_ASSET_NAME}.sha256"
+    release_manifest = package_dir / "geo-citation-lab-manifest.json"
+
+    _write_deterministic_zip(viewer, archive)
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    checksum.write_text(f"{digest}  {archive.name}\n", encoding="utf-8")
+    _copy_file(MANIFEST_PATH, release_manifest)
+    _copy_file(REPO_ROOT / "scripts" / "install.sh", package_dir / "install.sh")
+    _copy_file(REPO_ROOT / "scripts" / "install.ps1", package_dir / "install.ps1")
+
+    return {
+        "archive": archive,
+        "checksum": checksum,
+        "manifest": release_manifest,
+        "shell_installer": package_dir / "install.sh",
+        "powershell_installer": package_dir / "install.ps1",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build the lightweight GEO Citation Lab viewer."
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Viewer output directory. Existing directories are replaced only under dist/.",
+    )
+    parser.add_argument(
+        "--package",
+        action="store_true",
+        help="Create release assets after building the viewer.",
+    )
+    parser.add_argument(
+        "--package-dir",
+        type=Path,
+        default=DEFAULT_PACKAGE_DIR,
+        help="Release asset output directory.",
+    )
+    args = parser.parse_args()
+
+    viewer = build_viewer(args.output)
+    total_bytes = sum(path.stat().st_size for path in viewer.rglob("*") if path.is_file())
+    print(f"viewer_path={viewer.resolve()}")
+    print(f"viewer_uncompressed_bytes={total_bytes}")
+
+    if args.package:
+        assets = package_viewer(viewer, args.package_dir)
+        for name, path in assets.items():
+            print(f"{name}={path.resolve()}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,285 @@
+[CmdletBinding()]
+param(
+    [string]$InstallDir,
+    [string]$AssetBase = "https://github.com/yaojingang/geo-citation-lab/releases/download/v0.1.0",
+    [switch]$NoOpen
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$archiveName = "geo-citation-lab-viewer.zip"
+$checksumName = "$archiveName.sha256"
+$installMarker = ".geo-citation-lab-install"
+$checksumMarker = ".installed-checksum"
+$filesManifest = "geo-citation-lab-files.sha256"
+$filesChecksumMarker = ".installed-files-checksum"
+
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    $InstallDir = Join-Path $env:LOCALAPPDATA "GeoCitationLab\viewer"
+}
+
+$InstallDir = [System.IO.Path]::GetFullPath($InstallDir)
+$installRoot = [System.IO.Path]::GetPathRoot($InstallDir)
+$userProfile = [System.IO.Path]::GetFullPath($env:USERPROFILE)
+if ($InstallDir -eq $installRoot -or $InstallDir -eq $userProfile) {
+    throw "Refusing to install into a broad system or user-profile directory: $InstallDir"
+}
+if ((Test-Path -LiteralPath $InstallDir -PathType Leaf)) {
+    throw "Installation target exists and is not a directory: $InstallDir"
+}
+if ((Test-Path -LiteralPath $InstallDir -PathType Container) -and
+    -not (Test-Path -LiteralPath (Join-Path $InstallDir $installMarker) -PathType Leaf)) {
+    throw "Existing directory is not managed by this installer: $InstallDir"
+}
+
+$installParent = Split-Path -Parent $InstallDir
+New-Item -ItemType Directory -Path $installParent -Force | Out-Null
+$temporaryDir = Join-Path ([System.IO.Path]::GetTempPath()) "geo-citation-lab-$([guid]::NewGuid())"
+$stageDir = "$InstallDir.new.$PID"
+$backupDir = $null
+New-Item -ItemType Directory -Path $temporaryDir | Out-Null
+
+function Copy-ReleaseAsset {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    $base = $AssetBase.TrimEnd("/", "\")
+    if ($base -match "^https?://") {
+        Invoke-WebRequest -Uri "$base/$Name" -OutFile $Destination
+    }
+    elseif ($base -match "^file://") {
+        $localBase = ([uri]$base).LocalPath
+        Copy-Item -LiteralPath (Join-Path $localBase $Name) -Destination $Destination
+    }
+    else {
+        Copy-Item -LiteralPath (Join-Path $base $Name) -Destination $Destination
+    }
+}
+
+function Test-ViewerFileTree {
+    param(
+        [Parameter(Mandatory = $true)][string]$Root,
+        [Parameter(Mandatory = $true)][bool]$RequireMarker
+    )
+
+    try {
+        $manifestPath = Join-Path $Root $filesManifest
+        if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+            return $false
+        }
+        $manifestItem = Get-Item -LiteralPath $manifestPath
+        if (($manifestItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+            return $false
+        }
+        $manifestDigest = (
+            Get-FileHash -LiteralPath $manifestPath -Algorithm SHA256
+        ).Hash.ToLowerInvariant()
+        if ($RequireMarker) {
+            $markerPath = Join-Path $Root $filesChecksumMarker
+            if (-not (Test-Path -LiteralPath $markerPath -PathType Leaf)) {
+                return $false
+            }
+            if ((Get-Content -LiteralPath $markerPath -Raw).Trim() -ne $manifestDigest) {
+                return $false
+            }
+        }
+
+        $rootPrefix = [System.IO.Path]::GetFullPath(
+            $Root + [System.IO.Path]::DirectorySeparatorChar
+        )
+        $fileCount = 0
+        foreach ($line in Get-Content -LiteralPath $manifestPath -Encoding UTF8) {
+            if ($line -notmatch "^([0-9a-f]{64})  (.+)$") {
+                return $false
+            }
+            $expectedDigest = $Matches[1]
+            $relativePath = $Matches[2]
+            if ([System.IO.Path]::IsPathRooted($relativePath) -or
+                $relativePath.Contains("\")) {
+                return $false
+            }
+            $destination = [System.IO.Path]::GetFullPath(
+                (Join-Path $Root $relativePath.Replace(
+                    "/",
+                    [System.IO.Path]::DirectorySeparatorChar
+                ))
+            )
+            if (-not $destination.StartsWith(
+                $rootPrefix,
+                [System.StringComparison]::OrdinalIgnoreCase
+            )) {
+                return $false
+            }
+            if (-not (Test-Path -LiteralPath $destination -PathType Leaf)) {
+                return $false
+            }
+            $item = Get-Item -LiteralPath $destination
+            if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+                return $false
+            }
+            $actualDigest = (
+                Get-FileHash -LiteralPath $destination -Algorithm SHA256
+            ).Hash.ToLowerInvariant()
+            if ($actualDigest -ne $expectedDigest) {
+                return $false
+            }
+            $fileCount += 1
+        }
+        return $fileCount -gt 0
+    }
+    catch {
+        return $false
+    }
+}
+
+try {
+    $archivePath = Join-Path $temporaryDir $archiveName
+    $checksumPath = Join-Path $temporaryDir $checksumName
+    Copy-ReleaseAsset -Name $archiveName -Destination $archivePath
+    Copy-ReleaseAsset -Name $checksumName -Destination $checksumPath
+
+    $checksumLine = (Get-Content -LiteralPath $checksumPath -TotalCount 1).Trim()
+    $expectedChecksum = ($checksumLine -split "\s+")[0].ToLowerInvariant()
+    if ($expectedChecksum -notmatch "^[0-9a-f]{64}$") {
+        throw "Release checksum is malformed"
+    }
+
+    $actualChecksum = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualChecksum -ne $expectedChecksum) {
+        throw "Release checksum verification failed"
+    }
+
+    $installedChecksumPath = Join-Path $InstallDir $checksumMarker
+    if ((Test-Path -LiteralPath (Join-Path $InstallDir "index.html") -PathType Leaf) -and
+        (Test-Path -LiteralPath (Join-Path $InstallDir "geo-citation-lab-manifest.json") -PathType Leaf) -and
+        (Test-Path -LiteralPath $installedChecksumPath -PathType Leaf) -and
+        ((Get-Content -LiteralPath $installedChecksumPath -Raw).Trim() -eq $expectedChecksum) -and
+        (Test-ViewerFileTree -Root $InstallDir -RequireMarker $true)) {
+        $entrypoint = Join-Path $InstallDir "index.html"
+        $installedManifest = Get-Content `
+            -LiteralPath (Join-Path $InstallDir "geo-citation-lab-manifest.json") `
+            -Raw -Encoding UTF8 | ConvertFrom-Json
+        Write-Output "status=already-installed"
+        Write-Output "distribution_version=$($installedManifest.distribution_version)"
+        Write-Output "install_path=$InstallDir"
+        Write-Output "entrypoint=$entrypoint"
+        if (-not $NoOpen) {
+            try {
+                Start-Process $entrypoint
+            }
+            catch {
+                Write-Output "open_manually=$entrypoint"
+            }
+        }
+        return
+    }
+
+    if (Test-Path -LiteralPath $stageDir) {
+        throw "Temporary installation path already exists: $stageDir"
+    }
+    New-Item -ItemType Directory -Path $stageDir | Out-Null
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $stageRoot = [System.IO.Path]::GetFullPath(
+        $stageDir + [System.IO.Path]::DirectorySeparatorChar
+    )
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($archivePath)
+    try {
+        [long]$uncompressedSize = 0
+        foreach ($entry in $archive.Entries) {
+            $uncompressedSize += $entry.Length
+            $destination = [System.IO.Path]::GetFullPath(
+                (Join-Path $stageDir $entry.FullName)
+            )
+            if (-not $destination.StartsWith(
+                $stageRoot,
+                [System.StringComparison]::OrdinalIgnoreCase
+            )) {
+                throw "Release archive contains an unsafe path: $($entry.FullName)"
+            }
+            $unixFileType = ($entry.ExternalAttributes -shr 16) -band 0xF000
+            if ($unixFileType -eq 0xA000) {
+                throw "Release archive contains a symbolic link: $($entry.FullName)"
+            }
+        }
+        if ($uncompressedSize -gt (15 * 1024 * 1024)) {
+            throw "Release archive exceeds the 15 MiB extraction limit"
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+
+    Expand-Archive -LiteralPath $archivePath -DestinationPath $stageDir
+
+    $stageEntrypoint = Join-Path $stageDir "index.html"
+    if (-not (Test-Path -LiteralPath $stageEntrypoint -PathType Leaf)) {
+        throw "Release archive does not contain index.html"
+    }
+    if (-not (Test-ViewerFileTree -Root $stageDir -RequireMarker $false)) {
+        throw "Release archive file integrity verification failed"
+    }
+    $releaseManifestPath = Join-Path $stageDir "geo-citation-lab-manifest.json"
+    if (-not (Test-Path -LiteralPath $releaseManifestPath -PathType Leaf)) {
+        throw "Release archive does not contain its manifest"
+    }
+    $releaseManifest = Get-Content -LiteralPath $releaseManifestPath -Raw -Encoding UTF8 |
+        ConvertFrom-Json
+    $distributionVersion = [string]$releaseManifest.distribution_version
+    if ($distributionVersion -notmatch "^[0-9]+\.[0-9]+\.[0-9]+$") {
+        throw "Release manifest has no valid distribution version"
+    }
+    Set-Content -LiteralPath (Join-Path $stageDir $installMarker) `
+        -Value "managed-by=geo-citation-lab-installer"
+    Set-Content -LiteralPath (Join-Path $stageDir $checksumMarker) `
+        -Value $expectedChecksum
+    $filesManifestDigest = (
+        Get-FileHash -LiteralPath (Join-Path $stageDir $filesManifest) -Algorithm SHA256
+    ).Hash.ToLowerInvariant()
+    Set-Content -LiteralPath (Join-Path $stageDir $filesChecksumMarker) `
+        -Value $filesManifestDigest
+
+    if (Test-Path -LiteralPath $InstallDir -PathType Container) {
+        $timestamp = (Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ")
+        $backupDir = "$InstallDir.previous.$timestamp.$PID"
+        Move-Item -LiteralPath $InstallDir -Destination $backupDir
+    }
+
+    try {
+        Move-Item -LiteralPath $stageDir -Destination $InstallDir
+    }
+    catch {
+        if ($backupDir -and (Test-Path -LiteralPath $backupDir -PathType Container)) {
+            Move-Item -LiteralPath $backupDir -Destination $InstallDir
+        }
+        throw "Installation failed; the previous installation was restored. $($_.Exception.Message)"
+    }
+
+    $entrypoint = Join-Path $InstallDir "index.html"
+    Write-Output "status=installed"
+    Write-Output "distribution_version=$distributionVersion"
+    Write-Output "install_path=$InstallDir"
+    Write-Output "entrypoint=$entrypoint"
+    if ($backupDir) {
+        Write-Output "backup_path=$backupDir"
+    }
+    if (-not $NoOpen) {
+        try {
+            Start-Process $entrypoint
+        }
+        catch {
+            Write-Output "open_manually=$entrypoint"
+        }
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $temporaryDir) {
+        Remove-Item -LiteralPath $temporaryDir -Recurse -Force
+    }
+    if (Test-Path -LiteralPath $stageDir) {
+        Remove-Item -LiteralPath $stageDir -Recurse -Force
+    }
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ASSET_BASE="https://github.com/yaojingang/geo-citation-lab/releases/download/v0.1.0"
+INSTALL_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/geo-citation-lab/viewer"
+NO_OPEN=0
+ARCHIVE_NAME="geo-citation-lab-viewer.zip"
+CHECKSUM_NAME="${ARCHIVE_NAME}.sha256"
+INSTALL_MARKER=".geo-citation-lab-install"
+CHECKSUM_MARKER=".installed-checksum"
+FILES_MANIFEST="geo-citation-lab-files.sha256"
+FILES_CHECKSUM_MARKER=".installed-files-checksum"
+
+usage() {
+  command cat <<'EOF'
+Install the lightweight GEO Citation Lab viewer.
+
+Usage:
+  bash install.sh [--dir PATH] [--asset-base URL_OR_PATH] [--no-open]
+
+Options:
+  --dir PATH        Installation directory.
+  --asset-base SRC  Release URL or local release-asset directory.
+  --no-open         Install without opening the viewer in a browser.
+  --help            Show this help text.
+EOF
+}
+
+# Install the lightweight GEO Citation Lab viewer.
+#
+# Usage:
+#   bash install.sh [--dir PATH] [--asset-base URL_OR_PATH] [--no-open]
+#
+# Options:
+#   --dir PATH        Installation directory.
+#   --asset-base SRC  Release URL or local release-asset directory.
+#   --no-open         Install without opening the viewer in a browser.
+#   --help            Show this help text.
+
+while (($#)); do
+  case "$1" in
+    --dir)
+      [[ $# -ge 2 ]] || { echo "error: --dir requires a path" >&2; exit 2; }
+      INSTALL_DIR="$2"
+      shift 2
+      ;;
+    --asset-base)
+      [[ $# -ge 2 ]] || { echo "error: --asset-base requires a source" >&2; exit 2; }
+      ASSET_BASE="$2"
+      shift 2
+      ;;
+    --no-open)
+      NO_OPEN=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+install_name="$(basename "$INSTALL_DIR")"
+install_parent="$(dirname "$INSTALL_DIR")"
+if [[ -z "$install_name" || "$install_name" == "." || "$install_name" == ".." ]]; then
+  echo "error: unsafe installation directory: $INSTALL_DIR" >&2
+  exit 2
+fi
+mkdir -p "$install_parent"
+install_parent="$(cd "$install_parent" && pwd -P)"
+INSTALL_DIR="$install_parent/$install_name"
+
+if [[ "$INSTALL_DIR" == "/" || "$INSTALL_DIR" == "$HOME" ]]; then
+  echo "error: refusing to install into a broad system or home directory" >&2
+  exit 2
+fi
+if [[ -e "$INSTALL_DIR" && ! -d "$INSTALL_DIR" ]]; then
+  echo "error: installation target exists and is not a directory: $INSTALL_DIR" >&2
+  exit 2
+fi
+if [[ -d "$INSTALL_DIR" && ! -f "$INSTALL_DIR/$INSTALL_MARKER" ]]; then
+  echo "error: existing directory is not managed by this installer: $INSTALL_DIR" >&2
+  exit 2
+fi
+
+temporary_dir="$(mktemp -d "${TMPDIR:-/tmp}/geo-citation-lab.XXXXXX")"
+stage_dir="${INSTALL_DIR}.new.$$"
+backup_dir=""
+
+cleanup() {
+  rm -rf -- "$temporary_dir"
+  if [[ -d "$stage_dir" ]]; then
+    rm -rf -- "$stage_dir"
+  fi
+}
+trap cleanup EXIT
+
+fetch_asset() {
+  local name="$1"
+  local destination="$2"
+  local base="${ASSET_BASE%/}"
+  case "$base" in
+    http://*|https://*)
+      command -v curl >/dev/null 2>&1 || {
+        echo "error: curl is required for remote installation" >&2
+        return 1
+      }
+      curl --fail --location --retry 3 --silent --show-error \
+        "$base/$name" --output "$destination"
+      ;;
+    file://*)
+      cp -- "${base#file://}/$name" "$destination"
+      ;;
+    *)
+      cp -- "$base/$name" "$destination"
+      ;;
+  esac
+}
+
+fetch_asset "$ARCHIVE_NAME" "$temporary_dir/$ARCHIVE_NAME"
+fetch_asset "$CHECKSUM_NAME" "$temporary_dir/$CHECKSUM_NAME"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  HASH_TOOL="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  HASH_TOOL="shasum"
+else
+  echo "error: sha256sum or shasum is required to verify the download" >&2
+  exit 1
+fi
+
+sha256_file() {
+  local path="$1"
+  if [[ "$HASH_TOOL" == "sha256sum" ]]; then
+    sha256sum "$path" | awk '{ print $1 }'
+  else
+    shasum -a 256 "$path" | awk '{ print $1 }'
+  fi
+}
+
+verify_file_tree() {
+  local root="$1"
+  local require_marker="$2"
+  local manifest="$root/$FILES_MANIFEST"
+  local marker="$root/$FILES_CHECKSUM_MARKER"
+  local manifest_digest
+  local marker_digest
+  local checksum_line
+  local expected_digest
+  local relative_path
+  local actual_digest
+  local file_count=0
+
+  [[ -f "$manifest" && ! -L "$manifest" ]] || return 1
+  manifest_digest="$(sha256_file "$manifest")"
+  if [[ "$require_marker" == "1" ]]; then
+    [[ -f "$marker" && ! -L "$marker" ]] || return 1
+    marker_digest="$(tr -d '[:space:]' < "$marker")"
+    [[ "$marker_digest" == "$manifest_digest" ]] || return 1
+  fi
+
+  while IFS= read -r checksum_line || [[ -n "$checksum_line" ]]; do
+    expected_digest="${checksum_line%%  *}"
+    relative_path="${checksum_line#*  }"
+    [[ "$expected_digest" =~ ^[0-9a-f]{64}$ ]] || return 1
+    [[ -n "$relative_path" && "$relative_path" != "$checksum_line" ]] || return 1
+    case "$relative_path" in
+      /*|..|../*|*/..|*/../*|*\\*)
+        return 1
+        ;;
+    esac
+    [[ -f "$root/$relative_path" && ! -L "$root/$relative_path" ]] || return 1
+    actual_digest="$(sha256_file "$root/$relative_path")"
+    [[ "$actual_digest" == "$expected_digest" ]] || return 1
+    ((file_count += 1))
+  done < "$manifest"
+
+  ((file_count > 0))
+}
+
+expected_checksum="$(awk 'NR == 1 { print $1 }' "$temporary_dir/$CHECKSUM_NAME")"
+if [[ ! "$expected_checksum" =~ ^[0-9a-fA-F]{64}$ ]]; then
+  echo "error: release checksum is malformed" >&2
+  exit 1
+fi
+
+actual_checksum="$(sha256_file "$temporary_dir/$ARCHIVE_NAME")"
+
+actual_checksum="$(printf '%s' "$actual_checksum" | tr '[:upper:]' '[:lower:]')"
+expected_checksum="$(printf '%s' "$expected_checksum" | tr '[:upper:]' '[:lower:]')"
+if [[ "$actual_checksum" != "$expected_checksum" ]]; then
+  echo "error: release checksum verification failed" >&2
+  exit 1
+fi
+
+if [[ -f "$INSTALL_DIR/index.html" ]] &&
+   [[ -f "$INSTALL_DIR/geo-citation-lab-manifest.json" ]] &&
+   [[ -f "$INSTALL_DIR/$CHECKSUM_MARKER" ]] &&
+   [[ "$(tr -d '[:space:]' < "$INSTALL_DIR/$CHECKSUM_MARKER")" == "$expected_checksum" ]] &&
+   verify_file_tree "$INSTALL_DIR" 1; then
+  entrypoint="$INSTALL_DIR/index.html"
+  installed_version="$(
+    sed -n 's/^[[:space:]]*"distribution_version":[[:space:]]*"\([^"]*\)".*/\1/p' \
+      "$INSTALL_DIR/geo-citation-lab-manifest.json" | head -n 1
+  )"
+  echo "status=already-installed"
+  echo "distribution_version=${installed_version:-unknown}"
+  echo "install_path=$INSTALL_DIR"
+  echo "entrypoint=$entrypoint"
+  if ((NO_OPEN == 0)); then
+    if command -v open >/dev/null 2>&1; then
+      open "$entrypoint" || echo "open_manually=$entrypoint"
+    elif command -v xdg-open >/dev/null 2>&1; then
+      xdg-open "$entrypoint" || echo "open_manually=$entrypoint"
+    elif command -v cmd.exe >/dev/null 2>&1; then
+      cmd.exe /C start "" "$(cygpath -w "$entrypoint" 2>/dev/null || printf '%s' "$entrypoint")" ||
+        echo "open_manually=$entrypoint"
+    fi
+  fi
+  exit 0
+fi
+
+command -v unzip >/dev/null 2>&1 || {
+  echo "error: unzip is required to install the viewer" >&2
+  exit 1
+}
+
+archive_size="$(unzip -l "$temporary_dir/$ARCHIVE_NAME" | awk 'END { print $1 }')"
+if [[ ! "$archive_size" =~ ^[0-9]+$ ]] || ((archive_size > 15 * 1024 * 1024)); then
+  echo "error: release archive exceeds the 15 MiB extraction limit" >&2
+  exit 1
+fi
+while IFS= read -r archive_entry; do
+  case "$archive_entry" in
+    /*|../*|*/../*|*\\..\\*)
+      echo "error: release archive contains an unsafe path: $archive_entry" >&2
+      exit 1
+      ;;
+  esac
+done < <(unzip -Z1 "$temporary_dir/$ARCHIVE_NAME")
+
+if unzip -Z -l "$temporary_dir/$ARCHIVE_NAME" |
+   awk '$1 ~ /^l/ { found = 1 } END { exit(found ? 0 : 1) }'; then
+  echo "error: release archive contains a symbolic link" >&2
+  exit 1
+fi
+
+if [[ -e "$stage_dir" ]]; then
+  echo "error: temporary installation path already exists: $stage_dir" >&2
+  exit 1
+fi
+mkdir -p "$stage_dir"
+unzip -q "$temporary_dir/$ARCHIVE_NAME" -d "$stage_dir"
+
+if find "$stage_dir" -type l -print -quit | grep -q .; then
+  echo "error: release archive extracted a symbolic link" >&2
+  exit 1
+fi
+if [[ ! -f "$stage_dir/index.html" ]]; then
+  echo "error: release archive does not contain index.html" >&2
+  exit 1
+fi
+if ! verify_file_tree "$stage_dir" 0; then
+  echo "error: release archive file integrity verification failed" >&2
+  exit 1
+fi
+distribution_version="$(
+  sed -n 's/^[[:space:]]*"distribution_version":[[:space:]]*"\([^"]*\)".*/\1/p' \
+    "$stage_dir/geo-citation-lab-manifest.json" | head -n 1
+)"
+if [[ ! "$distribution_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: release manifest has no valid distribution version" >&2
+  exit 1
+fi
+printf '%s\n' "managed-by=geo-citation-lab-installer" > "$stage_dir/$INSTALL_MARKER"
+printf '%s\n' "$expected_checksum" > "$stage_dir/$CHECKSUM_MARKER"
+printf '%s\n' "$(sha256_file "$stage_dir/$FILES_MANIFEST")" \
+  > "$stage_dir/$FILES_CHECKSUM_MARKER"
+
+if [[ -d "$INSTALL_DIR" ]]; then
+  backup_dir="${INSTALL_DIR}.previous.$(date -u +%Y%m%dT%H%M%SZ).$$"
+  mv -- "$INSTALL_DIR" "$backup_dir"
+fi
+
+if ! mv -- "$stage_dir" "$INSTALL_DIR"; then
+  if [[ -n "$backup_dir" && -d "$backup_dir" ]]; then
+    mv -- "$backup_dir" "$INSTALL_DIR"
+  fi
+  echo "error: installation failed; the previous installation was restored" >&2
+  exit 1
+fi
+
+entrypoint="$INSTALL_DIR/index.html"
+echo "status=installed"
+echo "distribution_version=$distribution_version"
+echo "install_path=$INSTALL_DIR"
+echo "entrypoint=$entrypoint"
+if [[ -n "$backup_dir" ]]; then
+  echo "backup_path=$backup_dir"
+fi
+
+if ((NO_OPEN == 0)); then
+  if command -v open >/dev/null 2>&1; then
+    open "$entrypoint" || echo "open_manually=$entrypoint"
+  elif command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$entrypoint" || echo "open_manually=$entrypoint"
+  elif command -v cmd.exe >/dev/null 2>&1; then
+    cmd.exe /C start "" "$(cygpath -w "$entrypoint" 2>/dev/null || printf '%s' "$entrypoint")" ||
+      echo "open_manually=$entrypoint"
+  else
+    echo "open_manually=$entrypoint"
+  fi
+fi

--- a/scripts/verify_distribution.py
+++ b/scripts/verify_distribution.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import csv
 import hashlib
 import json
+import os
 import shutil
 import stat
 import subprocess
@@ -393,6 +394,8 @@ def _run_shell_rejection_tests(package_dir: Path, root: Path) -> None:
 def _run_powershell_install_if_available(
     package_dir: Path, install_dir: Path
 ) -> bool:
+    if os.name != "nt":
+        return False
     executable = shutil.which("pwsh")
     if not executable:
         return False
@@ -497,7 +500,7 @@ def main() -> int:
         print(
             "powershell_install=pass"
             if powershell_verified
-            else "powershell_install=skipped-pwsh-unavailable"
+            else "powershell_install=skipped-non-windows-or-pwsh-unavailable"
         )
         print(f"viewer_uncompressed_bytes={total_bytes}")
 

--- a/scripts/verify_distribution.py
+++ b/scripts/verify_distribution.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+"""Verify viewer contents, release assets, links, and local installation."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import shutil
+import stat
+import subprocess
+import tempfile
+import zipfile
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+from build_viewer import _javascript_string_literal
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BUILD_SCRIPT = REPO_ROOT / "scripts" / "build_viewer.py"
+MANIFEST_PATH = REPO_ROOT / "deploy" / "manifest.json"
+REQUIRED_FILES = {
+    "index.html",
+    ".nojekyll",
+    "geo-citation-lab-manifest.json",
+    "geo-citation-lab-files.sha256",
+    "LICENSE",
+    "LICENSE-CODE",
+    "LICENSE-CONTENT",
+    "THIRD_PARTY_NOTICES.md",
+    "01-geo-experiment-data-report/04-repet/final_report.html",
+    "02-geo-aeo-ai-search-papers/index.html",
+    "02-geo-aeo-ai-search-papers/00_资料说明/论文清单.csv",
+    "03-cn-geo-citation-dataset/reports/final/CN-GEO_多维数据分析报告.html",
+}
+BANNED_SUFFIXES = {".pdf", ".parquet", ".duckdb", ".jsonl", ".ttf"}
+
+
+class LinkCollector(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: list[str] = []
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        for name, value in attrs:
+            if name in {"href", "src"} and value:
+                self.links.append(value)
+
+
+def _local_link_target(html_file: Path, value: str) -> Path | None:
+    if not value or value.startswith(("#", "data:", "mailto:", "javascript:")):
+        return None
+    if "${" in value:
+        return None
+    parsed = urlparse(value)
+    if parsed.scheme or parsed.netloc or value.startswith("/"):
+        return None
+    path_text = unquote(parsed.path)
+    if not path_text:
+        return None
+    target = (html_file.parent / path_text).resolve()
+    if path_text.endswith("/"):
+        target = target / "index.html"
+    return target
+
+
+def _verify_links(viewer: Path) -> None:
+    missing: list[str] = []
+    for html_file in viewer.rglob("*.html"):
+        parser = LinkCollector()
+        parser.feed(html_file.read_text(encoding="utf-8"))
+        for value in parser.links:
+            target = _local_link_target(html_file, value)
+            if target is not None and not target.exists():
+                missing.append(f"{html_file.relative_to(viewer)} -> {value}")
+    if missing:
+        raise AssertionError("Missing local viewer links:\n" + "\n".join(missing))
+
+
+def _verify_archive(viewer: Path, package_dir: Path, manifest: dict) -> None:
+    package_files = {
+        path.name for path in package_dir.iterdir() if path.is_file()
+    }
+    assert package_files == set(manifest["release_assets"]), (
+        "Release package files differ from manifest release_assets"
+    )
+    archive = package_dir / "geo-citation-lab-viewer.zip"
+    checksum_file = package_dir / "geo-citation-lab-viewer.zip.sha256"
+    expected_checksum = checksum_file.read_text(encoding="utf-8").split()[0]
+    actual_checksum = hashlib.sha256(archive.read_bytes()).hexdigest()
+    assert actual_checksum == expected_checksum, "Release archive checksum mismatch"
+
+    viewer_files = {
+        path.relative_to(viewer).as_posix()
+        for path in viewer.rglob("*")
+        if path.is_file()
+    }
+    assert REQUIRED_FILES <= viewer_files, "Viewer is missing required files"
+    banned = sorted(
+        path for path in viewer_files if Path(path).suffix.lower() in BANNED_SUFFIXES
+    )
+    assert not banned, f"Viewer contains excluded binary assets: {banned}"
+    noise = sorted(
+        path
+        for path in viewer_files
+        if "__pycache__" in Path(path).parts
+        or Path(path).name in {".DS_Store", ".pytest_cache"}
+        or Path(path).suffix == ".pyc"
+    )
+    assert not noise, f"Viewer contains local cache files: {noise}"
+
+    total_bytes = sum(
+        path.stat().st_size for path in viewer.rglob("*") if path.is_file()
+    )
+    max_bytes = manifest["modes"]["viewer"]["max_uncompressed_mib"] * 1024 * 1024
+    assert total_bytes <= max_bytes, (
+        f"Viewer exceeds size limit: {total_bytes} > {max_bytes}"
+    )
+
+    with zipfile.ZipFile(archive) as bundle:
+        archive_files = {name for name in bundle.namelist() if not name.endswith("/")}
+        assert archive_files == viewer_files, "Archive and viewer file lists differ"
+        for name in archive_files:
+            parts = Path(name).parts
+            assert not Path(name).is_absolute() and ".." not in parts, (
+                f"Unsafe archive path: {name}"
+            )
+
+    file_manifest = viewer / "geo-citation-lab-files.sha256"
+    listed_files: set[str] = set()
+    for line in file_manifest.read_text(encoding="utf-8").splitlines():
+        digest, separator, relative = line.partition("  ")
+        assert separator and len(digest) == 64
+        assert all(character in "0123456789abcdef" for character in digest)
+        assert relative not in listed_files
+        listed_files.add(relative)
+        target = viewer / relative
+        assert target.is_file() and not target.is_symlink()
+        assert hashlib.sha256(target.read_bytes()).hexdigest() == digest
+    assert listed_files == viewer_files - {"geo-citation-lab-files.sha256"}
+
+
+def _verify_catalog(viewer: Path) -> None:
+    catalog = (
+        viewer / "02-geo-aeo-ai-search-papers" / "index.html"
+    ).read_text(encoding="utf-8")
+    assert "window.GEO_VIEWER_CSV =" in catalog, "Paper CSV was not embedded"
+    assert "window.GEO_VIEWER_USE_SOURCE_PDF_URLS = true;" in catalog
+    assert "const EMBEDDED_CSV = window.GEO_VIEWER_CSV || \"\";" in catalog
+    assert "const USE_SOURCE_PDF_URLS =" in catalog
+    assert "let csv = EMBEDDED_CSV;" in catalog
+    assert "function safeExternalUrl(value)" in catalog
+    assert 'parsed.protocol === "https:" || parsed.protocol === "http:"' in catalog
+    assert 'escapeHtml(encodeURI(paper.filePath))' in catalog
+    assert 'rel="noopener noreferrer"' in catalog
+
+    csv_path = (
+        viewer
+        / "02-geo-aeo-ai-search-papers"
+        / "00_资料说明"
+        / "论文清单.csv"
+    )
+    with csv_path.open(encoding="utf-8-sig", newline="") as source:
+        rows = list(csv.DictReader(source))
+    assert rows, "Paper catalog CSV is empty"
+    for row in rows:
+        parsed = urlparse(row["URL"])
+        assert parsed.scheme in {"http", "https"} and parsed.netloc, (
+            f"Paper catalog has an unsafe source URL: {row['URL']}"
+        )
+
+    hostile_literal = _javascript_string_literal(
+        '</script><script>alert("x")</script>&>\u2028\u2029'
+    )
+    assert "</script" not in hostile_literal.lower()
+    assert "\\u003c/script\\u003e" in hostile_literal
+    assert "\\u0026" in hostile_literal
+    assert "\\u2028" in hostile_literal and "\\u2029" in hostile_literal
+
+
+def _verify_licenses(viewer: Path, manifest: dict) -> None:
+    licensing = manifest["licensing"]
+    license_files = {
+        licensing["scope_file"],
+        licensing["code"]["file"],
+        licensing["original_content"]["file"],
+        licensing["third_party_notices"],
+    }
+    assert license_files == set(manifest["deployment"]["required_notice_files"])
+    for name in license_files:
+        source = REPO_ROOT / name
+        bundled = viewer / name
+        assert source.is_file() and bundled.is_file()
+        assert bundled.read_bytes() == source.read_bytes()
+
+    mit_text = (REPO_ROOT / licensing["code"]["file"]).read_text(encoding="utf-8")
+    assert mit_text.startswith("MIT License\n")
+    assert "Permission is hereby granted, free of charge" in mit_text
+    assert 'THE SOFTWARE IS PROVIDED "AS IS"' in mit_text
+
+    content_text = (REPO_ROOT / licensing["original_content"]["file"]).read_text(
+        encoding="utf-8"
+    )
+    assert "Creative Commons Attribution 4.0 International" in content_text
+    assert "https://creativecommons.org/licenses/by/4.0/" in content_text
+    assert licensing["original_content"]["attribution"] in content_text.replace(
+        '"', ""
+    ).replace("\n> ", " ").replace("\n", " ")
+
+    root_index = (viewer / "index.html").read_text(encoding="utf-8")
+    catalog = (
+        viewer / "02-geo-aeo-ai-search-papers" / "index.html"
+    ).read_text(encoding="utf-8")
+    for html in (root_index, catalog):
+        assert 'rel="license"' in html
+        assert "https://creativecommons.org/licenses/by/4.0/" in html
+
+
+def _verify_skill() -> None:
+    skill_dir = REPO_ROOT / "skills" / "geo-citation-lab"
+    skill_text = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert skill_text.startswith("---\nname: geo-citation-lab\n")
+    assert "\ndescription: " in skill_text.split("---", 2)[1]
+    assert "TODO" not in skill_text
+    assert "deployment.requires_license_compliance" in skill_text
+    assert "required_notice_files" in skill_text
+    assert "release_status: released" in skill_text
+
+    agent_instructions = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    assert "deployment.requires_license_compliance" in agent_instructions
+    assert "required_notice_files" in agent_instructions
+    assert "release_status" in agent_instructions
+
+    interface_text = (skill_dir / "agents" / "openai.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert 'display_name: "GEO Citation Lab"' in interface_text
+    assert "$geo-citation-lab" in interface_text
+
+
+def _run_shell_install(package_dir: Path, install_dir: Path) -> None:
+    command = [
+        "bash",
+        str(REPO_ROOT / "scripts" / "install.sh"),
+        "--asset-base",
+        str(package_dir),
+        "--dir",
+        str(install_dir),
+        "--no-open",
+    ]
+    first = subprocess.run(command, check=True, text=True, capture_output=True)
+    assert "status=installed" in first.stdout
+    assert "distribution_version=0.1.0" in first.stdout
+    assert (install_dir / "index.html").is_file()
+
+    second = subprocess.run(command, check=True, text=True, capture_output=True)
+    assert "status=already-installed" in second.stdout
+    assert "distribution_version=0.1.0" in second.stdout
+    assert not list(install_dir.parent.glob(f"{install_dir.name}.previous.*"))
+
+    report_relative = Path(
+        "01-geo-experiment-data-report/04-repet/final_report.html"
+    )
+    (install_dir / report_relative).unlink()
+    third = subprocess.run(command, check=True, text=True, capture_output=True)
+    assert "status=installed" in third.stdout
+    assert (install_dir / "index.html").is_file()
+    assert (install_dir / report_relative).is_file()
+    backups = list(install_dir.parent.glob(f"{install_dir.name}.previous.*"))
+    assert len(backups) == 1
+    assert (backups[0] / ".geo-citation-lab-install").is_file()
+    assert (backups[0] / "index.html").is_file()
+    assert not (backups[0] / report_relative).exists()
+
+
+def _run_shell_rejection_tests(package_dir: Path, root: Path) -> None:
+    command_prefix = [
+        "bash",
+        str(REPO_ROOT / "scripts" / "install.sh"),
+        "--no-open",
+    ]
+
+    unmanaged = root / "unmanaged-target"
+    unmanaged.mkdir()
+    sentinel = unmanaged / "keep.txt"
+    sentinel.write_text("preserve", encoding="utf-8")
+    unmanaged_result = subprocess.run(
+        command_prefix
+        + [
+            "--asset-base",
+            str(package_dir),
+            "--dir",
+            str(unmanaged),
+        ],
+        text=True,
+        capture_output=True,
+    )
+    assert unmanaged_result.returncode != 0
+    assert "is not managed by this installer" in unmanaged_result.stderr
+    assert sentinel.read_text(encoding="utf-8") == "preserve"
+
+    corrupt_assets = root / "corrupt-assets"
+    shutil.copytree(package_dir, corrupt_assets)
+    (corrupt_assets / "geo-citation-lab-viewer.zip.sha256").write_text(
+        "0" * 64 + "  geo-citation-lab-viewer.zip\n",
+        encoding="utf-8",
+    )
+    corrupt_target = root / "corrupt-target"
+    corrupt_result = subprocess.run(
+        command_prefix
+        + [
+            "--asset-base",
+            str(corrupt_assets),
+            "--dir",
+            str(corrupt_target),
+        ],
+        text=True,
+        capture_output=True,
+    )
+    assert corrupt_result.returncode != 0
+    assert "checksum verification failed" in corrupt_result.stderr
+    assert not corrupt_target.exists()
+
+    unsafe_assets = root / "unsafe-assets"
+    unsafe_assets.mkdir()
+    unsafe_archive = unsafe_assets / "geo-citation-lab-viewer.zip"
+    with zipfile.ZipFile(unsafe_archive, "w") as bundle:
+        bundle.writestr("../escape.txt", "blocked")
+        bundle.writestr("index.html", "<!doctype html>")
+    unsafe_digest = hashlib.sha256(unsafe_archive.read_bytes()).hexdigest()
+    (unsafe_assets / "geo-citation-lab-viewer.zip.sha256").write_text(
+        f"{unsafe_digest}  geo-citation-lab-viewer.zip\n",
+        encoding="utf-8",
+    )
+    unsafe_target = root / "unsafe-target"
+    unsafe_result = subprocess.run(
+        command_prefix
+        + [
+            "--asset-base",
+            str(unsafe_assets),
+            "--dir",
+            str(unsafe_target),
+        ],
+        text=True,
+        capture_output=True,
+    )
+    assert unsafe_result.returncode != 0
+    assert "contains an unsafe path" in unsafe_result.stderr
+    assert not (root / "escape.txt").exists()
+
+    symlink_assets = root / "symlink-assets"
+    symlink_assets.mkdir()
+    symlink_archive = symlink_assets / "geo-citation-lab-viewer.zip"
+    outside_marker = root / "outside-install-marker"
+    outside_marker.write_text("preserve", encoding="utf-8")
+    link_entry = zipfile.ZipInfo(".geo-citation-lab-install")
+    link_entry.create_system = 3
+    link_entry.external_attr = (stat.S_IFLNK | 0o777) << 16
+    with zipfile.ZipFile(symlink_archive, "w") as bundle:
+        bundle.writestr(link_entry, str(outside_marker))
+        bundle.writestr("index.html", "<!doctype html>")
+        bundle.writestr(
+            "geo-citation-lab-manifest.json",
+            '{"distribution_version":"0.1.0"}',
+        )
+    symlink_digest = hashlib.sha256(symlink_archive.read_bytes()).hexdigest()
+    (symlink_assets / "geo-citation-lab-viewer.zip.sha256").write_text(
+        f"{symlink_digest}  geo-citation-lab-viewer.zip\n",
+        encoding="utf-8",
+    )
+    symlink_target = root / "symlink-target"
+    symlink_result = subprocess.run(
+        command_prefix
+        + [
+            "--asset-base",
+            str(symlink_assets),
+            "--dir",
+            str(symlink_target),
+        ],
+        text=True,
+        capture_output=True,
+    )
+    assert symlink_result.returncode != 0
+    assert "contains a symbolic link" in symlink_result.stderr
+    assert outside_marker.read_text(encoding="utf-8") == "preserve"
+    assert not symlink_target.exists()
+
+
+def _run_powershell_install_if_available(
+    package_dir: Path, install_dir: Path
+) -> bool:
+    executable = shutil.which("pwsh")
+    if not executable:
+        return False
+    command = [
+        executable,
+        "-NoProfile",
+        "-File",
+        str(REPO_ROOT / "scripts" / "install.ps1"),
+        "-AssetBase",
+        str(package_dir),
+        "-InstallDir",
+        str(install_dir),
+        "-NoOpen",
+    ]
+    first = subprocess.run(command, check=True, text=True, capture_output=True)
+    assert "status=installed" in first.stdout
+    assert "distribution_version=0.1.0" in first.stdout
+    second = subprocess.run(command, check=True, text=True, capture_output=True)
+    assert "status=already-installed" in second.stdout
+    assert "distribution_version=0.1.0" in second.stdout
+    report_relative = Path(
+        "01-geo-experiment-data-report/04-repet/final_report.html"
+    )
+    (install_dir / report_relative).unlink()
+    third = subprocess.run(command, check=True, text=True, capture_output=True)
+    assert "status=installed" in third.stdout
+    assert (install_dir / "index.html").is_file()
+    assert (install_dir / report_relative).is_file()
+    assert len(list(install_dir.parent.glob(f"{install_dir.name}.previous.*"))) == 1
+    return True
+
+
+def main() -> int:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == 1
+    assert manifest["default_mode"] == "viewer"
+    assert manifest["distribution_version"] == "0.1.0"
+    assert manifest["release_status"] in {"pending", "released"}
+    assert manifest["modes"]["viewer"]["runtime_requirements"] == []
+    version = manifest["distribution_version"]
+    release_base = (
+        "https://github.com/yaojingang/geo-citation-lab/releases/download/"
+        f"v{version}"
+    )
+    assert manifest["modes"]["viewer"]["asset"].startswith(release_base + "/")
+    assert manifest["modes"]["viewer"]["checksum"].startswith(release_base + "/")
+    assert manifest["licensing"]["code"]["spdx"] == "MIT"
+    assert manifest["licensing"]["original_content"]["spdx"] == "CC-BY-4.0"
+    assert manifest["deployment"]["requires_redistribution_authorization"] is False
+    assert manifest["deployment"]["requires_license_compliance"] is True
+    assert set(manifest["deployment"]["required_notice_files"]) <= REQUIRED_FILES
+    shell_installer = (REPO_ROOT / "scripts" / "install.sh").read_text(
+        encoding="utf-8"
+    )
+    powershell_installer = (REPO_ROOT / "scripts" / "install.ps1").read_text(
+        encoding="utf-8"
+    )
+    assert f'ASSET_BASE="{release_base}"' in shell_installer
+    assert f'[string]$AssetBase = "{release_base}"' in powershell_installer
+    max_mib = manifest["modes"]["viewer"]["max_uncompressed_mib"]
+    assert f"archive_size > {max_mib} * 1024 * 1024" in shell_installer
+    assert f"$uncompressedSize -gt ({max_mib} * 1024 * 1024)" in powershell_installer
+    _verify_skill()
+
+    with tempfile.TemporaryDirectory(prefix="geo-citation-lab-verify-") as temporary:
+        root = Path(temporary)
+        viewer = root / "viewer"
+        package_dir = root / "release"
+        subprocess.run(
+            [
+                "python3",
+                str(BUILD_SCRIPT),
+                "--output",
+                str(viewer),
+                "--package",
+                "--package-dir",
+                str(package_dir),
+            ],
+            check=True,
+        )
+
+        _verify_links(viewer)
+        _verify_catalog(viewer)
+        _verify_licenses(viewer, manifest)
+        _verify_archive(viewer, package_dir, manifest)
+        _run_shell_install(package_dir, root / "shell-install")
+        _run_shell_rejection_tests(package_dir, root)
+        powershell_verified = _run_powershell_install_if_available(
+            package_dir, root / "powershell-install"
+        )
+
+        total_bytes = sum(
+            path.stat().st_size for path in viewer.rglob("*") if path.is_file()
+        )
+        print("viewer_links=pass")
+        print("viewer_catalog=pass")
+        print("viewer_licenses=pass")
+        print("agent_skill=pass")
+        print("viewer_archive=pass")
+        print("shell_install=pass")
+        print("shell_rejection_tests=pass")
+        print(
+            "powershell_install=pass"
+            if powershell_verified
+            else "powershell_install=skipped-pwsh-unavailable"
+        )
+        print(f"viewer_uncompressed_bytes={total_bytes}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/geo-citation-lab/SKILL.md
+++ b/skills/geo-citation-lab/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: geo-citation-lab
+description: Install, open, download, or deploy GEO Citation Lab from its GitHub repository. Use when a user asks to install the lightweight offline viewer, open the research reports locally, download the full GEO citation dataset, prepare the analysis environment, or publish the viewer to GitHub Pages.
+---
+
+# GEO Citation Lab
+
+Use the repository distribution contract to choose the smallest safe delivery mode and report the
+result in plain language.
+
+## Route the request
+
+- For “安装”, “打开”, or “本地阅读”, install the lightweight Viewer.
+- For “部署” or “GitHub Pages”, confirm the GitHub target before making external changes.
+- For “完整数据” or “分析环境”, state the approximate size and clone the full repository.
+- For reading only, open `https://yaojingang.github.io/geo-citation-lab/`.
+
+Read `deploy/manifest.json` from the repository root. If no checkout is available, fetch
+`https://raw.githubusercontent.com/yaojingang/geo-citation-lab/main/deploy/manifest.json`.
+Treat the manifest as the source of asset names, versions, size limits, and entrypoints.
+
+## Install the Viewer
+
+1. Require `release_status: released`, then download the version-pinned asset and matching
+   installer. The raw repository copies of `scripts/install.sh` and `scripts/install.ps1` are the
+   source fallback.
+2. Inspect the installer before execution.
+3. Run `scripts/install.sh` on macOS/Linux or `scripts/install.ps1` on Windows.
+4. Let the installer download and verify the latest ZIP and SHA-256 sidecar.
+5. Open the returned `index.html` unless the user requested download only.
+6. Report `status`, `install_path`, `entrypoint`, and `backup_path` when present.
+
+Never pipe an unreviewed remote script into a shell. Preserve an existing installation unless its
+directory contains `.geo-citation-lab-install`.
+
+If `release_status` is `pending` or the pinned Release is unavailable, report that remote
+installation is not published. A maintainer inside a checkout may build local assets with
+`python3 scripts/build_viewer.py --package`.
+
+## Deploy to GitHub Pages
+
+1. Resolve the authenticated GitHub identity and exact target repository.
+2. Read `deployment.requires_license_compliance` and `required_notice_files`. Preserve every
+   required notice file, the requested attribution, and an indication of changes to CC BY 4.0
+   content.
+3. Confirm the target and public visibility.
+4. Run `python3 scripts/verify_distribution.py`.
+5. Confirm before changing an existing Pages publishing source.
+6. Use `.github/workflows/publish.yml` to deploy the generated Viewer.
+7. Read the completed workflow state and return its public URL.
+
+Repository creation, visibility changes, Pages source changes, tags, pushes, and releases require
+explicit user approval.
+
+## Download full data
+
+State that the complete working tree is approximately 568 MiB. Clone the repository only after the
+user requests full data or analysis. For `03-cn-geo-citation-dataset`, follow its README and use
+Python 3.11 or newer with `uv`.
+
+Read `LICENSE`, `LICENSE-CODE`, `LICENSE-CONTENT`, and `THIRD_PARTY_NOTICES.md` before
+redistribution. Code is MIT licensed, original GEO Citation Lab content is CC BY 4.0, and
+third-party materials retain their source terms.

--- a/skills/geo-citation-lab/agents/openai.yaml
+++ b/skills/geo-citation-lab/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GEO Citation Lab"
+  short_description: "安装、打开、下载和部署 GEO Citation Lab"
+  default_prompt: "使用 $geo-citation-lab 安装轻量阅读版并在本机打开。"


### PR DESCRIPTION
## Summary

- Add a lightweight Viewer build with self-contained reports, a searchable paper catalog, deterministic ZIP output, and version-pinned release metadata.
- Add macOS/Linux and Windows installers with archive and per-file SHA-256 verification, idempotent updates, backups, missing-file repair, and malicious archive rejection.
- Add repository instructions and an agent Skill for natural-language install, open, full-data, and GitHub Pages deployment requests.
- Add GitHub Actions jobs for Viewer validation, Windows installer testing, Pages deployment, and versioned Release assets.
- Add split licensing: MIT for software and automation, CC BY 4.0 for original reports, documentation, visualizations, and catalog metadata. The Viewer preserves all required license and third-party notice files.

## Why

A user can give an AI client the repository URL and ask it to install or deploy GEO Citation Lab without learning Git, Python, Node, or Docker. The distribution contract keeps downloads small, fixes the requested version, and records licensing requirements for downstream Pages deployments.

## User impact

The Viewer is about 5.55 MB uncompressed and excludes paper PDFs, research datasets, fonts, and other large binary assets. Full-data requests continue to use the complete repository. Remote installation remains marked `pending` until the first `v0.1.0` Release is published.

## Validation

- `python3 scripts/verify_distribution.py`
- Python compilation and Shell syntax checks
- ShellCheck 0.11.0
- actionlint 1.7.12 and YAML parsing
- Agent Skill validation
- JavaScript compilation for generated Viewer pages
- macOS/Linux install, repeat install, missing-report repair, checksum rejection, unmanaged-directory protection, path traversal rejection, and ZIP symlink rejection
- License scope, attribution, notice-file, Viewer archive, and local-link verification
- GitHub Actions run 30098147896: Ubuntu build passed in 21 seconds and Windows installer verification passed in 30 seconds

The Windows job verified first install, repeat install, and missing-report repair. Pages deployment and Release creation are skipped for pull requests. Local browser automation could not open the generated `file://` page under the browser security policy; generated JavaScript parsing and static link checks passed.