### PR TITLE
Add MiniMax provider for website classification

### DIFF
--- a/01-geo-experiment-data-report/03-pipeline/analyze_gemini.py
+++ b/01-geo-experiment-data-report/03-pipeline/analyze_gemini.py
@@ -21,6 +21,11 @@ gemini_client = None
 if GEMINI_API_KEY and GEMINI_API_KEY != 'YOUR_NEW_GEMINI_API_KEY':
     gemini_client = genai.Client(api_key=GEMINI_API_KEY)
 
+# MiniMax client (optional): built lazily so the module still imports when the
+# OpenAI SDK is not installed. Falls back to Gemini when MINIMAX_API_KEY is unset.
+from minimax_client import build_minimax_client, categorize_website as _minimax_categorize
+minimax_client = build_minimax_client()
+
 # ================= 1. HTML 解析 =================
 def extract_citations(html_text):
     cited_domains = set()
@@ -106,8 +111,10 @@ def get_dataforseo_technologies(domain):
 
     return data
 
-# ================= 3. Gemini 分类 =================
+# ================= 3. 网站分类 =================
 def categorize_website(domain):
+    if minimax_client:
+        return _minimax_categorize(domain, minimax_client)
     if not gemini_client:
         return "null"
 

--- a/01-geo-experiment-data-report/03-pipeline/analyze_gpt.py
+++ b/01-geo-experiment-data-report/03-pipeline/analyze_gpt.py
@@ -23,6 +23,11 @@ gemini_client = None
 if GEMINI_API_KEY and GEMINI_API_KEY != 'YOUR_NEW_GEMINI_API_KEY':
     gemini_client = genai.Client(api_key=GEMINI_API_KEY)
 
+# MiniMax client (optional): built lazily so the module still imports when the
+# OpenAI SDK is not installed. Falls back to Gemini when MINIMAX_API_KEY is unset.
+from minimax_client import build_minimax_client, categorize_website as _minimax_categorize
+minimax_client = build_minimax_client()
+
 # ================= 1. HTML 解析 =================
 
 def extract_citations(soup):
@@ -102,9 +107,11 @@ def get_dataforseo_technologies(domain):
 
     return data
 
-# ================= 3. Gemini 智能分类 =================
+# ================= 3. 网站分类 =================
 
 def categorize_website(domain):
+    if minimax_client:
+        return _minimax_categorize(domain, minimax_client)
     if not gemini_client:
         return "null"
 

--- a/01-geo-experiment-data-report/03-pipeline/analyze_perplexity.py
+++ b/01-geo-experiment-data-report/03-pipeline/analyze_perplexity.py
@@ -22,6 +22,11 @@ gemini_client = None
 if GEMINI_API_KEY:
     gemini_client = genai.Client(api_key=GEMINI_API_KEY)
 
+# MiniMax client (optional): built lazily so the module still imports when the
+# OpenAI SDK is not installed. Falls back to Gemini when MINIMAX_API_KEY is unset.
+from minimax_client import build_minimax_client, categorize_website as _minimax_categorize
+minimax_client = build_minimax_client()
+
 # ================= 1. Perplexity HTML 解析 =================
 def extract_citations_perplexity(html_text):
     cited_domains = set()
@@ -88,6 +93,8 @@ def get_dataforseo_technologies(domain):
     return data
 
 def categorize_website(domain):
+    if minimax_client:
+        return _minimax_categorize(domain, minimax_client)
     if not gemini_client: return "null"
     prompt = f"你是SEO分析师。判断域名 {domain} 属于以下哪一类：新闻 / blog / 行业垂类 / 测评类 / 官网 / 电商 / 其他。只能返回一个词。如果无法判断，请回复 null。"
     try:

--- a/01-geo-experiment-data-report/03-pipeline/minimax_client.py
+++ b/01-geo-experiment-data-report/03-pipeline/minimax_client.py
@@ -1,0 +1,88 @@
+"""MiniMax LLM provider for the citation-analysis pipeline.
+
+The website-categorization step previously relied on a single LLM provider
+(hard-coded ``gemini-2.5-flash``). This module adds a MiniMax client so the
+same SEO categorization can be served by MiniMax instead. The client targets
+the OpenAI-compatible Chat Completions endpoint and supports both the global
+(``api.minimax.io``) and China (``api.minimaxi.com``) base URLs, selectable via
+``MINIMAX_REGION``. The model is selectable between ``MiniMax-M3`` and
+``MiniMax-M2.7`` via ``MINIMAX_MODEL``.
+
+The OpenAI SDK is imported lazily, so importing this module never fails even
+when the SDK is not installed; :func:`build_minimax_client` simply returns
+``None`` and the pipeline falls back to its default provider.
+"""
+
+import os
+
+# Regional endpoints: global (api.minimax.io) and China (api.minimaxi.com) base
+# URLs for the OpenAI-compatible Chat Completions API.
+MINIMAX_BASE_URLS = {
+    "global_en": "https://api.minimax.io/v1",
+    "cn_zh": "https://api.minimaxi.com/v1",
+}
+
+# Selectable MiniMax text models.
+MINIMAX_MODELS = ("MiniMax-M3", "MiniMax-M2.7")
+
+DEFAULT_REGION = "global_en"
+DEFAULT_MODEL = "MiniMax-M3"
+
+
+def resolve_base_url(region=None):
+    """Return the OpenAI-compatible base URL for the given region."""
+    region = (region or os.environ.get("MINIMAX_REGION", "")).strip() or DEFAULT_REGION
+    return MINIMAX_BASE_URLS.get(region, MINIMAX_BASE_URLS[DEFAULT_REGION])
+
+
+def resolve_model(model=None):
+    """Return a selectable MiniMax model, falling back to the default."""
+    model = (model or os.environ.get("MINIMAX_MODEL", "")).strip() or DEFAULT_MODEL
+    return model if model in MINIMAX_MODELS else DEFAULT_MODEL
+
+
+def build_minimax_client(api_key=None, region=None, model=None):
+    """Build an OpenAI-compatible MiniMax client.
+
+    Returns a ``(client, model)`` tuple, or ``None`` when the API key is
+    absent or the OpenAI SDK is unavailable, so callers can degrade to their
+    default provider.
+    """
+    api_key = (api_key or os.environ.get("MINIMAX_API_KEY", "")).strip()
+    if not api_key:
+        return None
+    try:
+        from openai import OpenAI
+    except Exception:
+        return None
+    base_url = resolve_base_url(region)
+    resolved_model = resolve_model(model)
+    client = OpenAI(api_key=api_key, base_url=base_url)
+    return client, resolved_model
+
+
+def categorize_website(domain, minimax_client=None):
+    """Classify a domain into an SEO category using MiniMax.
+
+    ``minimax_client`` is the ``(client, model)`` tuple returned by
+    :func:`build_minimax_client`. Returns ``"null"`` when no client is
+    available, mirroring the existing categorization contract.
+    """
+    if not minimax_client:
+        return "null"
+    client, model = minimax_client
+    prompt = (
+        f"你是SEO分析师。判断域名 {domain} 属于以下哪一类："
+        f"新闻 / blog / 行业垂类 / 测评类 / 官网 / 电商 / 其他。"
+        f"只能返回一个词。如果无法判断，请回复 null。"
+    )
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        result = (response.choices[0].message.content or "").strip()
+        return result if result else "null"
+    except Exception as e:
+        print(f"  [MiniMax 异常] {domain}: {e}")
+        return "null"

--- a/01-geo-experiment-data-report/03-pipeline/requirements.txt
+++ b/01-geo-experiment-data-report/03-pipeline/requirements.txt
@@ -3,3 +3,4 @@ lxml
 requests
 readability-lxml
 playwright
+openai

--- a/01-geo-experiment-data-report/03-pipeline/retry_ahrefs.py
+++ b/01-geo-experiment-data-report/03-pipeline/retry_ahrefs.py
@@ -17,6 +17,11 @@ gemini_client = None
 if GEMINI_API_KEY and GEMINI_API_KEY != 'YOUR_GEMINI_API_KEY':
     gemini_client = genai.Client(api_key=GEMINI_API_KEY)
 
+# MiniMax client (optional): built lazily so the module still imports when the
+# OpenAI SDK is not installed. Falls back to Gemini when MINIMAX_API_KEY is unset.
+from minimax_client import build_minimax_client, categorize_website as _minimax_categorize
+minimax_client = build_minimax_client()
+
 # 为 Ahrefs 量身定制的全新表头
 AHREFS_KEYS = [
     "文件名", "引用域名", "网站类型", 
@@ -80,6 +85,8 @@ def get_ahrefs_full_data(domain):
 
 def categorize_website(domain):
     """仅在万不得已时调用，增加超时保护"""
+    if minimax_client:
+        return _minimax_categorize(domain, minimax_client)
     if not gemini_client:
         return "null"
     prompt = f"你是SEO分析师。判断域名 {domain} 属于以下哪一类：新闻 / blog / 行业垂类 / 测评类 / 官网 / 电商 / 其他。只能返回一个词。如果无法判断，请回复 null。"

--- a/01-geo-experiment-data-report/03-pipeline/tests/test_minimax_client.py
+++ b/01-geo-experiment-data-report/03-pipeline/tests/test_minimax_client.py
@@ -1,0 +1,87 @@
+"""Unit tests for the MiniMax provider client and categorization dispatcher.
+
+These tests run without network access or the optional OpenAI SDK: they stub
+the chat-completions surface to verify the dispatcher routes to MiniMax and
+degrades gracefully when no client is configured.
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+PIPELINE_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PIPELINE_DIR))
+
+_spec = importlib.util.spec_from_file_location(
+    "minimax_client", PIPELINE_DIR / "minimax_client.py"
+)
+minimax_client = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(minimax_client)
+
+
+def test_resolve_base_url_defaults_and_regions():
+    assert minimax_client.resolve_base_url(None).endswith("/v1")
+    assert minimax_client.resolve_base_url("global_en") == "https://api.minimax.io/v1"
+    assert minimax_client.resolve_base_url("cn_zh") == "https://api.minimaxi.com/v1"
+    # Unknown region falls back to the global endpoint.
+    assert minimax_client.resolve_base_url("mars") == "https://api.minimax.io/v1"
+
+
+def test_resolve_model_selectable():
+    assert minimax_client.resolve_model(None) == "MiniMax-M3"
+    assert minimax_client.resolve_model("MiniMax-M2.7") == "MiniMax-M2.7"
+    assert minimax_client.resolve_model("MiniMax-M3") == "MiniMax-M3"
+    # Unknown model falls back to the default.
+    assert minimax_client.resolve_model("bogus") == "MiniMax-M3"
+
+
+def test_build_client_without_key_returns_none(monkeypatch=None):
+    os.environ.pop("MINIMAX_API_KEY", None)
+    assert minimax_client.build_minimax_client() is None
+
+
+def _fake_openai_client(content="新闻"):
+    """Build an object that mimics openai.OpenAI for chat.completions.create."""
+
+    class Message:
+        def __init__(self, content):
+            self.content = content
+
+    class Choice:
+        def __init__(self, content):
+            self.message = Message(content)
+
+    class Response:
+        def __init__(self, content):
+            self.choices = [Choice(content)]
+
+    class Completions:
+        def create(self, **kwargs):
+            assert "messages" in kwargs
+            return Response(content)
+
+    class Chat:
+        completions = Completions()
+
+    class Client:
+        chat = Chat()
+
+    return Client()
+
+
+def test_categorize_website_routes_to_minimax():
+    client = _fake_openai_client(content="新闻")
+    result = minimax_client.categorize_website("example.com", (client, "MiniMax-M3"))
+    assert result == "新闻"
+
+
+def test_categorize_website_without_client_returns_null():
+    assert minimax_client.categorize_website("example.com", None) == "null"
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok {name}")


### PR DESCRIPTION
Reason: The citation-analysis pipeline uses a single LLM provider and hard-codes gemini-2.5-flash for website classification; this adds a selectable MiniMax provider with global and China base URLs.

## Changes

- Add `01-geo-experiment-data-report/03-pipeline/minimax_client.py`: an OpenAI-compatible MiniMax client targeting the global (`https://api.minimax.io/v1`) and China (`https://api.minimaxi.com/v1`) Chat Completions endpoints, selectable via `MINIMAX_REGION`, with selectable `MiniMax-M3` / `MiniMax-M2.7` models via `MINIMAX_MODEL`. The OpenAI SDK is imported lazily, so the module imports cleanly even when the SDK is not installed; `build_minimax_client()` returns `None` when `MINIMAX_API_KEY` is unset so the pipeline keeps using its default provider.
- Route the website-categorization step in `analyze_gemini.py`, `analyze_gpt.py`, `analyze_perplexity.py`, and `retry_ahrefs.py` through the MiniMax client when configured, falling back to the existing provider otherwise. The SEO category prompt and `"null"` return contract are unchanged.
- Add `openai` to `01-geo-experiment-data-report/03-pipeline/requirements.txt`.
- Add `01-geo-experiment-data-report/03-pipeline/tests/test_minimax_client.py` covering regional endpoint resolution, model selection, client construction without a key, and the categorization dispatcher (MiniMax routing and graceful fallback).

## Checks

- `python3 -m py_compile` on all modified/new pipeline modules.
- `python3 tests/test_minimax_client.py` (unit tests, no network or SDK required).
